### PR TITLE
feat: check file for viruses with ajax request, WIP

### DIFF
--- a/ckanext/clamav/assets/js/clamav-scan-file.js
+++ b/ckanext/clamav/assets/js/clamav-scan-file.js
@@ -1,0 +1,98 @@
+/**
+ * CKAN ClamAV scan file
+ */
+ckan.module("clamav-scan-file", function ($, _) {
+    "use strict";
+
+    return {
+        initialize: function () {
+            $.proxyAll(this, /_/);
+
+            this.form = $("#resource-edit");
+
+            if (!this.form) {
+                console.log('clamav: no form found, skipping');
+                return;
+            }
+
+            // add event listener
+            this.form.find("input[type='file']").on('change', this._onFileChange);
+
+            // on init
+            this._appendTokenField();
+        },
+
+        _appendTokenField: function () {
+            this.tokenField = $('<input>').attr({
+                type: 'hidden',
+                name: 'clamav_token',
+            }).appendTo(this.form);
+        },
+
+        _onFileChange: function (e) {
+            if (e.target.files.length === 0) {
+                return;
+            }
+
+            this._onStartScan();
+
+            const self = this;
+            const file = e.target.files[0];
+
+            const formData = new FormData();
+            formData.append("upload", file);
+            formData.append("size", file.size);
+            var csrf_field = $('meta[name=csrf_field_name]').attr('content');
+            var csrf_token = $('meta[name=' + csrf_field + ']').attr('content');
+
+            $.ajax({
+                method: 'POST',
+                url: this.sandbox.client.url('/api/action/clamav_scan_file'),
+                data: formData,
+                cache: false,
+                contentType: false,
+                processData: false,
+                headers: {
+                    'X-CSRFToken': csrf_token
+                },
+                success: function (data) {
+                    console.log(data);
+                    if (data.result.success) {
+                        self._onScanSuccess(data.result);
+                    } else {
+                        self._onScanError(data.result);
+                    }
+                },
+            });
+        },
+
+        _onStartScan: function () {
+            this._toggleFormSubmit(true);
+            this.el.find('.info').text('Scanning...');
+
+            this.el.find('.spinner').show();
+            this.el.show();
+        },
+
+        _onScanSuccess: function (data) {
+            this.tokenField.attr("value", data.token);
+
+            this._toggleFormSubmit(false);
+            this.el.find('.info').text('');
+            this.el.find('.spinner').hide();
+            this.el.hide();
+        },
+
+        _onScanError: function (data) {
+            this.tokenField.attr("value", "");
+
+            this._toggleFormSubmit(false);
+            this.el.find('.info').text(data.error);
+            this.el.find('.spinner').hide();
+        },
+
+        _toggleFormSubmit: function (disabled) {
+            this.form.find('button[type="submit"]').prop('disabled', disabled);
+        },
+    };
+});

--- a/ckanext/clamav/assets/webassets.yml
+++ b/ckanext/clamav/assets/webassets.yml
@@ -1,0 +1,8 @@
+clamav-js:
+  filter: rjsmin
+  output: ckanext-clamav/%(version)s-clamav-js.js
+  extra:
+    preload:
+      - base/main
+  contents:
+    - js/clamav-scan-file.js

--- a/ckanext/clamav/logic/action.py
+++ b/ckanext/clamav/logic/action.py
@@ -1,0 +1,63 @@
+from __future__ import annotations
+
+from typing import Any
+from datetime import datetime as dt, timezone
+from datetime import timedelta as td
+
+import jwt
+
+import ckan.plugins.toolkit as tk
+from ckan.logic import validate
+from ckan.types import Context, DataDict
+
+from ckanext.clamav import utils
+from ckanext.clamav.logic import schema
+
+TOKEN_TTL = 3600  # 1 hour
+
+
+@validate(schema.clamav_scan_file)
+def clamav_scan_file(context: Context, data_dict: DataDict) -> dict[str, Any]:
+    # TODO: add a config option to set the max file size
+    if data_dict["size"] > 1024 * 1024 * 600:  # 600MB
+        raise tk.ValidationError({"upload": ["File is too large"]})
+
+    try:
+        utils.scan_file_for_viruses(data_dict)
+    except tk.ValidationError as e:
+        return {
+            "success": False,
+            "error": _format_error(e),
+            "token": _create_jwt_token(data_dict, safe=False),
+        }
+    except ConnectionResetError:
+        return {"success": False, "error": "ClamAV is not available"}
+
+    return {"success": True, "token": _create_jwt_token(data_dict)}
+
+
+def _format_error(e: tk.ValidationError) -> str:
+    # TODO: can we just use e.error_summary?
+    if "Virus checker" in e.error_dict:
+        return e.error_dict.get("Virus checker", [""])[0]  # type: ignore
+
+    return str(e)
+
+
+def _create_jwt_token(data_dict: DataDict, safe: bool = True) -> str:
+    """
+    Create a JWT token that will be used to verify, that the file has been scanned
+    """
+    now = dt.now(timezone.utc)
+
+    return jwt.encode(
+        {
+            "name": data_dict["upload"].filename,
+            "size": data_dict["size"],
+            "safe": safe,
+            "exp": now + td(seconds=TOKEN_TTL),
+            "created_at": now.timestamp(),
+        },
+        utils.get_secret(True),
+        algorithm="HS256",
+    )

--- a/ckanext/clamav/logic/schema.py
+++ b/ckanext/clamav/logic/schema.py
@@ -1,0 +1,12 @@
+from __future__ import annotations
+
+from ckan import types
+from ckan.logic.schema import validator_args
+
+
+@validator_args
+def clamav_scan_file(not_empty, int_validator, clamav_file_validator) -> types.Schema:
+    return {
+        "upload": [not_empty, clamav_file_validator],
+        "size": [not_empty, int_validator],
+    }

--- a/ckanext/clamav/logic/validators.py
+++ b/ckanext/clamav/logic/validators.py
@@ -1,0 +1,14 @@
+from __future__ import annotations
+
+from typing import Any
+
+from werkzeug.datastructures import FileStorage
+
+import ckan.plugins.toolkit as tk
+
+
+def clamav_file_validator(value: Any) -> Any:
+    if not isinstance(value, FileStorage):
+        raise tk.Invalid(tk._("File is required"))
+
+    return value

--- a/ckanext/clamav/plugin.py
+++ b/ckanext/clamav/plugin.py
@@ -1,12 +1,16 @@
 from typing import Any, Optional
+from datetime import datetime as dt, timezone
 
+import jwt
 import ckan.plugins as p
 from ckan.plugins import toolkit
 from ckan.common import CKANConfig
 
-from . import utils
+from ckanext.clamav import config, utils
 
 
+@toolkit.blanket.actions
+@toolkit.blanket.validators
 class ClamavPlugin(p.SingletonPlugin):
     p.implements(p.IConfigurer)
     p.implements(p.IUploader, inherit=True)
@@ -15,8 +19,7 @@ class ClamavPlugin(p.SingletonPlugin):
 
     def update_config(self, config: "CKANConfig"):
         toolkit.add_template_directory(config, "templates")
-        toolkit.add_public_directory(config, "public")
-        toolkit.add_resource("fanstatic", "clamav")
+        toolkit.add_resource("assets", "clamav")
 
     # IUploader
 
@@ -24,7 +27,57 @@ class ClamavPlugin(p.SingletonPlugin):
         if not data_dict.get("upload"):
             return
 
-        utils.scan_file_for_viruses(data_dict)
+        if config.upload_unscanned():
+            return
+
+        if not self._check_token(data_dict):
+            raise toolkit.ValidationError(
+                {"Virus checker": ["The file has not been scanned or is infected"]},
+            )
+
+    def _check_token(self, data_dict: dict[str, Any]) -> bool:
+        """Check if the file has been scanned and is safe
+
+        Args:
+            data_dict: The data dictionary from the resource edit form
+
+        Returns:
+            True if the file has been scanned and is safe, False otherwise
+        """
+        token = data_dict.get("clamav_token", "")
+        file = data_dict["upload"]
+
+        if not token:
+            return False
+
+        try:
+            token_data: dict[str, Any] = jwt.decode(
+                token,
+                utils.get_secret(False),
+                algorithms=["HS256"],
+            )
+        except (jwt.ExpiredSignatureError, jwt.DecodeError):
+            return False
+
+        if not token_data.get("safe"):
+            return False
+
+        import ipdb; ipdb.set_trace()
+
+        if (token_data.get("name") != file.filename) or (
+            token_data.get("size") != file.stream.seek(0, 2)
+        ):
+            return False
+
+        file.stream.seek(0)
+        # checking for filename and filesize provides reasonable security without being too expensive.
+        # While checking file content would be more secure, it would require re-scanning the file,
+        # defeating the purpose of the token. The combination of filename and size makes it much harder
+        # to substitute a malicious file while reusing a valid token.
+
+        return dt.fromtimestamp(token_data["exp"], tz=timezone.utc) < dt.now(
+            timezone.utc,
+        )
 
     def get_uploader(self, upload_to: str, old_filename: Optional[str]):
         return

--- a/ckanext/clamav/templates/package/resource_edit_base.html
+++ b/ckanext/clamav/templates/package/resource_edit_base.html
@@ -1,0 +1,11 @@
+{% ckan_extends %}
+
+{% block primary_content_inner %}
+    {% snippet 'snippets/clamav_scan.html' %}
+    {{ super() }}
+{% endblock %}
+
+{% block styles %}
+    {{ super() }}
+    {% asset 'clamav/clamav-js' %}
+{% endblock %}

--- a/ckanext/clamav/templates/snippets/clamav_scan.html
+++ b/ckanext/clamav/templates/snippets/clamav_scan.html
@@ -1,0 +1,7 @@
+<div data-module="clamav-scan-file" style="display: none; margin-bottom: 0.5rem">
+    <span class="spinner">
+        {% snippet 'snippets/svg/spinner.svg' %}
+    </span>
+
+    <span class="info"></span>
+</div>

--- a/ckanext/clamav/templates/snippets/svg/spinner.svg
+++ b/ckanext/clamav/templates/snippets/svg/spinner.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24">
+    <style>.spinner_P7sC{transform-origin:center;animation:spinner_svv2 .75s infinite
+        linear}@keyframes spinner_svv2{100%{transform:rotate(360deg)}}</style>
+    <path
+        d="M10.14,1.16a11,11,0,0,0-9,8.92A1.59,1.59,0,0,0,2.46,12,1.52,1.52,0,0,0,4.11,10.7a8,8,0,0,1,6.66-6.61A1.42,1.42,0,0,0,12,2.69h0A1.57,1.57,0,0,0,10.14,1.16Z"
+        class="spinner_P7sC" />
+</svg>

--- a/ckanext/clamav/tests/test_clamav_local.py
+++ b/ckanext/clamav/tests/test_clamav_local.py
@@ -90,7 +90,7 @@ class TestClamAvLocalDaemon:
 
             # Verify ClamAV blocked the file
             assert (
-                "{'virus checker': ['malware has been found. filename: eicar.com.txt, "
+                "{'virus checker': ['Malware has been found. filename: eicar.com.txt, "
                 "signature: win.test.eicar_hdb-1.']}" in str(excinfo.value).lower()
             ), str(excinfo.value).lower()
 

--- a/ckanext/clamav/tests/test_clamav_tcp.py
+++ b/ckanext/clamav/tests/test_clamav_tcp.py
@@ -130,7 +130,7 @@ class TestClamAvTcpAgent:
 
             # Verify ClamAV blocked the file
             assert (
-                "{'virus checker': ['malware has been found. filename: eicar.com.txt, "
+                "{'virus checker': ['Malware has been found. filename: eicar.com.txt, "
                 "signature: win.test.eicar_hdb-1.']}" in str(excinfo.value).lower()
                 in str(excinfo.value).lower()
             ), str(excinfo.value).lower()

--- a/ckanext/clamav/utils.py
+++ b/ckanext/clamav/utils.py
@@ -9,6 +9,7 @@ from ckan import logic
 from ckan import model
 from ckan.exceptions import CkanConfigurationException
 from ckan.types import ErrorDict
+from ckan.lib.api_token import _get_secret
 
 from . import config as c
 from .adapters import CustomClamdNetworkSocket
@@ -58,7 +59,7 @@ def scan_file_for_viruses(data_dict: dict[str, Any]) -> None:
             raise logic.ValidationError(err)
     elif status == ClamAvStatus.FOUND:
         error_msg: str = (
-            "malware has been found. "
+            "Malware has been found. "
             f"Filename: {file.filename}, signature: {signature}."
         )
         log.warning(error_msg)
@@ -104,7 +105,7 @@ def _scan_filestream(file: FileStorage) -> tuple[str, Optional[str]]:
         scan_result: Union[dict[str, tuple[str, Optional[str]]], None] = cd.instream(
             file.stream,
         )
-    except BufferTooLongError:
+    except (BufferTooLongError, BrokenPipeError):
         error_msg: str = (
             "The uploaded file exceeds the filesize limit. "
             "The file will not be scanned"
@@ -160,3 +161,11 @@ def _get_unscanned_file_message(file: FileStorage, pkg_id: str) -> str:
         "The unscanned file will be uploaded because unscanned fileupload is enabled. "
         f"File: {file.filename}, pkg: {pkg_id}, name: {file.filename or None}"
     )
+
+
+def get_secret(encode: bool) -> str:
+    """Return a secret string for a jwt encode/decode
+
+    We're using an internal func here, ideally, we either need to write a custom
+    one or to contribute into CKAN and make it public"""
+    return _get_secret(encode)


### PR DESCRIPTION
To address issue [#1](https://github.com/DataShades/ckanext-clamav/issues/1,), I've decided to rewrite the way we check for viruses. Now, there's a JavaScript script that listens for changes to the file field and sends the file to the backend. While the file is being scanned, the form submission is blocked. Once the scan is complete, the backend responds with or without a JWT token. This JWT token is then appended to the form and used on the backend after submission to verify that the submitted file is the same one that was scanned and is safe to upload.

This PR isn't completed yet. We still need to:
1. add few config options - `max_file_size` and `skip_large_file_scan` 
2. check remote files for viruses
3. fix tests, cause the new approach breaks them (that's why it's in a separate branch)

Also, it is worth to mention, that if we want to check big files, the clamd must be properly configured. At least, the `StreamMaxLength` must be set to a higher value. The default one is `100M`. 